### PR TITLE
Proposed upstreaming of changes requested by nvim-treesitter project.

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,42 +1,38 @@
-; highlights.scm
 ((identifier) @keyword
- (#match? @keyword "^(definition|permission|relation)$"))
+ (#any-of? @keyword "definition" "permission" "relation"))
 
-((permission_literal) @variable.builtin)
+(permission_literal) @variable.builtin
 
 (permission (identifier) @type)
 (relation (identifier) @constant)
 (perm_expression (identifier) @property)
-((block_start) @punctuation)
-((block_end) @punctuation)
+
+[
+  (block_start)
+  (block_end)
+] @punctuation.bracket
 
 (block (identifier) (identifier) @constructor)
 
-((plus_literal) @punctuation)
-((hash_literal) @comment)
+[
+  (plus_literal)
+  (pipe_literal)
+] @operator
 
-; relations
-((relation_literal) @function)
+(relation_literal) @function
 (rel_expression (identifier) @property)
-
-
-((pipe_literal) @punctuation)
 
 (relation
   (rel_expression
-    (
-  (hash_literal)
-  .
-  (identifier) @constant
-  ) @coment))
-
+    ((hash_literal)
+     . (identifier) @constant) @comment))
 
 (permission
- (perm_expression
-   (
-    (stabby)
-    .
-    (identifier)
-    @function) @punctuation))
+  (perm_expression
+    ((stabby)
+     . (identifier) @function) @operator))
 
-((comment) @comment)
+[
+  (hash_literal)
+  (comment)
+] @comment

--- a/queries/injections.scm
+++ b/queries/injections.scm
@@ -1,0 +1,2 @@
+((comment) @injection.content
+ (#set! injection.language "comment"))


### PR DESCRIPTION
Alright, the [PR](https://github.com/nvim-treesitter/nvim-treesitter/pull/5426) against `nvim-treesitter` got approved and I assume it will merge shortly. Reviewers there had a few requested changes to the `highlights.scm` file. Most of the changes are equivalent (e.g. whitespace changes, swapping `match?` for `any-of?`, and grouping queries together when they match the same capture).

The changes that were a bit more substantive were just to use different names in a few places (based on what `nvim-treesitter` listed as supported). For example, `@punctuation` was rejected so I changed it to either `@punctuation.bracket` (for the curly brackets) or `@operator` (for the plus sign, pipe, and stabby).

Anyway, I figured I would see about upstreaming these to your repository to keep the two highlights files in sync.

Checklist:

- [ ] All tests pass in CI.
- [ ] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [ ] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
