### PR TITLE
Fix typo in highlights file

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -35,7 +35,7 @@
   (hash_literal)
   .
   (identifier) @constant
-  ) @coment))
+  ) @comment))
 
 (call_expression
   (selector_expression


### PR DESCRIPTION
Checklist:

- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
