### PR TITLE
Remove second highlight capture for permission literal

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -10,9 +10,6 @@
     (permission_literal) @function
      (identifier) @property))
 
-
-((permission_literal) @variable.builtin)
-
 (permission (identifier) @type)
 (relation (identifier) @constant)
 (perm_expression (identifier) @property)


### PR DESCRIPTION
Please correct me if I am wrong, but I think there is an unnecessary second capture for the permission literal. The first one on line 10 captures it as `@function`. The second capture on line 14 captures it as `@variable.builtin`. As far as I know, permissions can only be defined within blocks so it seems unnecessary to capture it twice.

On the other hand, maybe the less-nested capture would be the more appealing of the two because then the word `permission` gets highlighted regardless of whether the user has written a complete permission out yet or not...

Checklist:

- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
