### PR TITLE
remove redundant relation literal highlight definition and fix permission literal capture name

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -7,7 +7,7 @@
 
 (block
   (permission
-    (permission_literal) @function
+    (permission_literal) @variable.builtin
      (identifier) @property))
 
 (permission (identifier) @type)
@@ -20,7 +20,6 @@
 ((hash_literal) @comment)
 
 ; relations
-((relation_literal) @function)
 (rel_expression (identifier) @property)
 
 


### PR DESCRIPTION
In https://github.com/mleonidas/tree-sitter-authzed/pull/9, I removed a redundant highlights definition for the `permission_literal` but I removed the second place it was captured which had previously had the effect of overwriting first captured style; long story short, this PR fixes that by applying the `variable.builtin` capture to permission literals which was the behavior we had previously.

This PR also removes the other redundant capture `relation_literal` but in that case both captures already agreed about the style of that literal.

Checklist:

- [x] All tests pass in CI.
- [x] There are sufficient tests for the new fix/feature.
- [x] Grammar rules have not been renamed unless absolutely necessary.
- [x] The conflicts section hasn't grown too much.
- [x] The parser size hasn't grown too much (check the value of STATE_COUNT in src/parser.c).
